### PR TITLE
Enable building Windows Server 2022

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LD_FLAGS = "-w -s -X github.com/cloudfoundry/stembuild/version.Version=${STEMCEL
 # These are the sources for StemcellAutomation.zip
 STEMCELL_AUTOMATION_PS1 := $(shell ls stemcell-automation/*ps1 | grep -iv Test)
 BOSH_AGENT_REPO ?= ${HOME}/go/src/github.com/cloudfoundry/bosh-agent
-LGPO_URL = 'https://www.microsoft.com/en-us/download/confirmation.aspx?id=55319&6B49FDFB-8E5B-4B07-BC31-15695C5A2143=1'
+LGPO_URL = 'https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/LGPO.zip'
 BOSH_GCS_URL = 'https://s3.amazonaws.com/bosh-gcscli/bosh-gcscli-0.0.6-windows-amd64.exe'
 # Ignore things under cis-merge* directory because the paths contain spaces and make doesn't like
 # that

--- a/modules/BOSH.Utils/BOSH.Utils.Tests.ps1
+++ b/modules/BOSH.Utils/BOSH.Utils.Tests.ps1
@@ -447,7 +447,7 @@ Describe "Clear-ProxySettings"  {
 
 Describe "Get-WUCerts" {
     BeforeEach {
-        Mock SST-Path { "certfile" } -ModuleName BOSH.Utils
+        Mock Get-SST-Path { "certfile" } -ModuleName BOSH.Utils
         Mock Invoke-Import-Certificate { } -ModuleName BOSH.Utils
         Mock Invoke-Certutil { } -ModuleName BOSH.Utils
         Mock Invoke-Remove-Item { } -ModuleName BOSH.Utils
@@ -456,7 +456,7 @@ Describe "Get-WUCerts" {
 
         Get-WUCerts
 
-        Assert-MockCalled SST-Path -Times 1 -Scope It -ModuleName BOSH.Utils
+        Assert-MockCalled Get-SST-Path -Times 1 -Scope It -ModuleName BOSH.Utils
         Assert-MockCalled Invoke-Certutil -Times 1 -Scope It -ModuleName BOSH.Utils -ParameterFilter { $generateSSTFromWU -eq "certfile" }
         Assert-MockCalled Invoke-Import-Certificate -Times 1 -Scope It -ModuleName BOSH.Utils -ParameterFilter { $CertStoreLocation -eq "Cert:\LocalMachine\Root" -and $FilePath -eq "certfile" }
         Assert-MockCalled Invoke-Remove-Item -Times 1 -Scope It -ModuleName BOSH.Utils -ParameterFilter { $path -eq "certfile" }

--- a/modules/BOSH.Utils/BOSH.Utils.psm1
+++ b/modules/BOSH.Utils/BOSH.Utils.psm1
@@ -292,6 +292,11 @@ function Get-OSVersion {
             Write-Log "Found OS version: Windows 2019"
             "windows2019"
         }
+        elseif ($osVersion -match "10\.0\.20348\..+")
+        {
+            Write-Log "Found OS version: Windows 2022"
+            "windows2022"
+        }
         else {
             throw "invalid OS detected"
         }
@@ -328,13 +333,13 @@ function Get-WinRMConfig {
 
 function Get-WUCerts {
     Write-Log "Loading certs from windows update server"
-    $sstfile = SST-Path
+    $sstfile = Get-SST-Path
     Invoke-Certutil -generateSSTFromWU $sstfile
     Invoke-Import-Certificate -CertStoreLocation Cert:\LocalMachine\Root -FilePath $sstfile
     Invoke-Remove-Item -path $sstfile
 }
 
-function SST-Path {
+function Get-SST-Path {
     return [System.IO.Path]::GetTempPath() + 'roots.sst'
 }
 

--- a/package_stemcell/config/output_config.go
+++ b/package_stemcell/config/output_config.go
@@ -41,7 +41,7 @@ func (c OutputConfig) ValidateConfig() error {
 
 func IsValidOS(os string) bool {
 	switch os {
-	case "2012R2", "1803", "2016", "2019":
+	case "2012R2", "1803", "2016", "2019", "2022":
 		return true
 	default:
 		return false

--- a/stemcell-automation/AutomationHelpers.Tests.ps1
+++ b/stemcell-automation/AutomationHelpers.Tests.ps1
@@ -690,7 +690,7 @@ Describe "Install-SecurityPoliciesAndRegistries" {
         { Install-SecurityPoliciesAndRegistries } | Should -Not -Throw
 
         Assert-MockCalled Set-InternetExplorerRegistries -Times 0 -Scope It
-        Assert-MockCalled Write-Log -Times 1 -Scope It -ParameterFilter { $Message -eq "Did not run Set-InternetExplorerRegistries because OS version was not 2019" }
+        Assert-MockCalled Write-Log -Times 1 -Scope It -ParameterFilter { $Message -eq "Did not run Set-InternetExplorerRegistries because OS version was not 2019 or 2022" }
 
     }
 

--- a/stemcell-automation/AutomationHelpers.ps1
+++ b/stemcell-automation/AutomationHelpers.ps1
@@ -333,8 +333,12 @@ function Validate-OSVersion
         {
             Write-Log "Found correct OS version: Windows Server 2019"
         }
+        elseif ($osVersion -match "10\.0\.20348\..+")
+        {
+            Write-Log "Found correct OS version: Windows Server 2022"
+        }
         else {
-            throw "OS Version Mismatch: Please use Windows Server 2019 as the OS on your targeted VM"
+            throw "OS Version Mismatch: Please use Windows Server 2019 or 2022 as the OS on your targeted VM"
         }
     }
     catch [Exception]
@@ -421,14 +425,14 @@ function Install-SecurityPoliciesAndRegistries
 {
     try
     {
-        $osVersion2019Regex = "10\.0\.17763\..+"
+        $osVersion2019or2022Regex = "10\.0\.(17763|20348)\..+"
         $osVersion = Get-OSVersionString
         Write-Log "osVersion: $osVersion"
-        if ($osVersion -match $osVersion2019Regex) {
+        if ($osVersion -match $osVersion2019or2022Regex) {
             Set-InternetExplorerRegistries
             Write-Log "Succesfully ran Set-InternetExplorerRegistries"
         } else {
-            Write-Log "Did not run Set-InternetExplorerRegistries because OS version was not 2019"
+            Write-Log "Did not run Set-InternetExplorerRegistries because OS version was not 2019 or 2022"
         }
     }
     catch [Exception]


### PR DESCRIPTION
We'd like to get a sense of what changes would be required to build a Windows Server 2022 stemcell.

We set Windows 2022 Registry entries for Explorer.

Drive-by:
- Update `LGPO.exe` download URL; old one was broken
- `SST-Path` → `Get-SST-Path`, makes linter happy

Fixes, when running `stembuild construct`:
```
OS Version Mismatch: Please use Windows Server 2019 as the OS on your targeted VM
```
```
invalid OS detected
```
```
versioning error; parsed os version is: 2022
```
Fixes, when running `stembuild package`:
```
Did not run Set-InternetExplorerRegistries because OS version was not 2019
```