### PR TITLE
Fix Makefile build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+.DS_Store
 .idea
 .envrc
 stembuild
 stembuild.exe
+StemcellAutomation.zip
 gordiff
 gordiff.exe
 temp


### PR DESCRIPTION
Add targets that download StemcellAutomation.zip dependencies from s3 to unblock local development of stembuild.

Since tar.exe, bosh-blobstore-s3.exe, bosh-blobstore-dav.exe [were removed from the BOSH agent repository](https://github.com/cloudfoundry/bosh-agent/commit/80d6b18efe25734d845884caf1d1c770ffc55551) this had the unfortunate side effect of breaking the stembuild make build target. The latest dependencies to build StemcellAutomation.zip are now downloaded from their respective s3 buckets that the official stembuild CI system uses.

The targets do require the use of `xq` (wrapper around jq that handles xml) to select the latest version of each dependencies in each s3 bucket.