### PR TITLE
Enable IMDSv2 in AWS Windows stemcell

### DIFF
--- a/modules/BOSH.Agent/BOSH.Agent.psm1
+++ b/modules/BOSH.Agent/BOSH.Agent.psm1
@@ -91,6 +91,7 @@ function Write-AgentConfig {
                 "URI" = "http://169.254.169.254"
                 "UserDataPath" = "/latest/user-data/"
                 "InstanceIDPath" = "/latest/meta-data/instance-id/"
+                "TokenPath" = "/latest/api/token"
             })
             "UseRegistry" = $true
           }


### PR DESCRIPTION
When the bosh-linux-stemcell-builder was updated to add IMDSv2 support to AWS Linux stemcells in commit
86bb00e0b64ea7ece71ed2775358fbab99cef033 (see:
<https://github.com/cloudfoundry/bosh-linux-stemcell-builder/commit/86bb00e0b64ea7ece71ed2775358fbab99cef033>), stembuild was not updated with the corresponding change.

This commit makes that change. It looks like without this change, Bosh Agents running in Windows on IMDSv2-only VMs will be unable to talk to the AWS Metadata Server, and will be unable to start. JIRA ticket BOSHWIN-43 was opened with a customer complaining of this very problem.

Commentary from the bosh-linux-stemcell-builder commit mentioned above follows:

- TokenPath must be set in `agent.json` in order for the bosh-agent to load metadata using the IMDSv2 protocol.
- This commit adds that field. It will be ignored unless the agent has been updated to expect it.

[#180052419] [TAS-94] Convert the Agent on AWS to use IMDSv2