### PR TITLE
Issue: #27

### DIFF
--- a/remotemanager/winrm_clientfactory.go
+++ b/remotemanager/winrm_clientfactory.go
@@ -18,6 +18,12 @@ func NewWinRmClientFactory(host, username, password string) *WinRMClientFactory 
 
 func (f *WinRMClientFactory) Build(timeout time.Duration) (WinRMClient, error) {
 	endpoint := winrm.NewEndpoint(f.host, WinRmPort, false, true, nil, nil, nil, timeout)
-	client, err := winrm.NewClient(endpoint, f.username, f.password)
+	params := winrm.NewParameters(
+		winrm.DefaultParameters.Timeout,
+		winrm.DefaultParameters.Locale,
+		winrm.DefaultParameters.EnvelopeSize,
+	)
+	params.AllowTimeout = true
+	client, err := winrm.NewClientWithParameters(endpoint, f.username, f.password, params)
 	return client, err
 }


### PR DESCRIPTION
Add rollback of "automatic retry on timeout" in winrm when executing the post reboot script. This should fix the hang reported during sysprep.

The previous PR #30 only modified the winrm timeout on file copy and not on command execution, where the actual hang was observed.