### PR TITLE
Logger improvements

### DIFF
--- a/colorlogger/colorLogger.go
+++ b/colorlogger/colorLogger.go
@@ -6,38 +6,44 @@ import (
 	"log"
 )
 
+const (
+	NONE  = -1
+	DEBUG = 0
+
+	debug             = "debug"
+	plainPrefixFormat = "%s:"
+	colorPrefixFormat = "\033[32m%s:\033[0m"
+)
+
 type colorLogger struct {
 	color    bool
 	logger   *log.Logger
 	logLevel int
 }
 
-const (
-	NONE  = -1
-	DEBUG = 0
-)
-
-var logLevelsNames = []string{"debug"}
-
-func ConstructLogger(logLevel int, color bool, writer io.Writer) *colorLogger {
-	logger := log.New(writer, "", 0)
-	loggerPlus := colorLogger{color, logger, logLevel}
-	return &loggerPlus
+type Logger interface {
+	Printf(format string, args ...interface{})
 }
 
-func (g *colorLogger) Logf(logLevel int, msg string) {
-	if g.logLevel >= logLevel && g.logLevel != NONE {
-		if g.color {
-			g.logger.Printf("\033[32m%s:\033[0m %s", logLevelsNames[logLevel], msg)
-		} else {
-			g.logger.Printf("%s: %s", logLevelsNames[logLevel], msg)
-
-		}
+func New(logLevel int, color bool, writer io.Writer) Logger {
+	return &colorLogger{
+		color:    color,
+		logger:   log.New(writer, "", 0),
+		logLevel: logLevel,
 	}
 }
 
-// This function is here so that existing Debugf outputs will still work.
-// Once we figure out how to properly deal with logging, this can be revisited
-func (g *colorLogger) Debugf(format string, a ...interface{}) {
-	g.Logf(DEBUG, fmt.Sprintf(format, a...))
+func (cl *colorLogger) Printf(format string, a ...interface{}) {
+	if cl.logLevel >= DEBUG && cl.logLevel != NONE {
+		cl.logger.Printf("%s %s", cl.prefix(), fmt.Sprintf(format, a...))
+	}
+}
+
+func (cl *colorLogger) prefix() string {
+	prefixFormat := plainPrefixFormat
+	if cl.color {
+		prefixFormat = colorPrefixFormat
+	}
+
+	return fmt.Sprintf(prefixFormat, debug)
 }

--- a/colorlogger/colorlogger_test.go
+++ b/colorlogger/colorlogger_test.go
@@ -10,50 +10,37 @@ import (
 )
 
 var _ = Describe("Stdout", func() {
-
 	It("write debug output when log level is debug", func() {
 		buf := bytes.Buffer{}
 
 		Expect(colorlogger.DEBUG).To(Equal(0))
-		logger := colorlogger.ConstructLogger(colorlogger.DEBUG, false, &buf)
+		logger := colorlogger.New(colorlogger.DEBUG, false, &buf)
 
 		message := "This is a test"
 
-		logger.Logf(colorlogger.DEBUG, message)
+		logger.Printf(message)
 		Expect(buf.String()).To(Equal("debug: " + message + "\n"))
 	})
 
 	It("write no debug output when log level is NONE", func() {
 		buf := bytes.Buffer{}
 
-		logger := colorlogger.ConstructLogger(colorlogger.NONE, false, &buf)
+		logger := colorlogger.New(colorlogger.NONE, false, &buf)
 
 		message := "This is a test"
 
-		logger.Logf(colorlogger.DEBUG, message)
-		Expect(buf.String()).To(BeEmpty())
-	})
-
-	It("write no none output when log level is NONE", func() {
-		buf := bytes.Buffer{}
-
-		logger := colorlogger.ConstructLogger(colorlogger.NONE, false, &buf)
-
-		message := "This is a test"
-
-		logger.Logf(colorlogger.NONE, message)
+		logger.Printf(message)
 		Expect(buf.String()).To(BeEmpty())
 	})
 
 	It("write colored debug output when log level is DEBUG and color is true", func() {
 		buf := bytes.Buffer{}
 
-		logger := colorlogger.ConstructLogger(colorlogger.DEBUG, true, &buf)
+		logger := colorlogger.New(colorlogger.DEBUG, true, &buf)
 
 		message := "This is a test"
 
-		logger.Logf(colorlogger.DEBUG, message)
+		logger.Printf(message)
 		Expect(buf.String()).To(Equal("\033[32mdebug:\033[0m " + message + "\n"))
 	})
-
 })

--- a/commandparser/commandparserfakes/fake_packager_factory.go
+++ b/commandparser/commandparserfakes/fake_packager_factory.go
@@ -4,18 +4,18 @@ package commandparserfakes
 import (
 	"sync"
 
+	"github.com/cloudfoundry/stembuild/colorlogger"
 	"github.com/cloudfoundry/stembuild/commandparser"
 	"github.com/cloudfoundry/stembuild/package_stemcell/config"
 )
 
 type FakePackagerFactory struct {
-	PackagerStub        func(config.SourceConfig, config.OutputConfig, int, bool) (commandparser.Packager, error)
+	PackagerStub        func(config.SourceConfig, config.OutputConfig, colorlogger.Logger) (commandparser.Packager, error)
 	packagerMutex       sync.RWMutex
 	packagerArgsForCall []struct {
 		arg1 config.SourceConfig
 		arg2 config.OutputConfig
-		arg3 int
-		arg4 bool
+		arg3 colorlogger.Logger
 	}
 	packagerReturns struct {
 		result1 commandparser.Packager
@@ -29,21 +29,20 @@ type FakePackagerFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakePackagerFactory) Packager(arg1 config.SourceConfig, arg2 config.OutputConfig, arg3 int, arg4 bool) (commandparser.Packager, error) {
+func (fake *FakePackagerFactory) Packager(arg1 config.SourceConfig, arg2 config.OutputConfig, arg3 colorlogger.Logger) (commandparser.Packager, error) {
 	fake.packagerMutex.Lock()
 	ret, specificReturn := fake.packagerReturnsOnCall[len(fake.packagerArgsForCall)]
 	fake.packagerArgsForCall = append(fake.packagerArgsForCall, struct {
 		arg1 config.SourceConfig
 		arg2 config.OutputConfig
-		arg3 int
-		arg4 bool
-	}{arg1, arg2, arg3, arg4})
+		arg3 colorlogger.Logger
+	}{arg1, arg2, arg3})
 	stub := fake.PackagerStub
 	fakeReturns := fake.packagerReturns
-	fake.recordInvocation("Packager", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("Packager", []interface{}{arg1, arg2, arg3})
 	fake.packagerMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -57,17 +56,17 @@ func (fake *FakePackagerFactory) PackagerCallCount() int {
 	return len(fake.packagerArgsForCall)
 }
 
-func (fake *FakePackagerFactory) PackagerCalls(stub func(config.SourceConfig, config.OutputConfig, int, bool) (commandparser.Packager, error)) {
+func (fake *FakePackagerFactory) PackagerCalls(stub func(config.SourceConfig, config.OutputConfig, colorlogger.Logger) (commandparser.Packager, error)) {
 	fake.packagerMutex.Lock()
 	defer fake.packagerMutex.Unlock()
 	fake.PackagerStub = stub
 }
 
-func (fake *FakePackagerFactory) PackagerArgsForCall(i int) (config.SourceConfig, config.OutputConfig, int, bool) {
+func (fake *FakePackagerFactory) PackagerArgsForCall(i int) (config.SourceConfig, config.OutputConfig, colorlogger.Logger) {
 	fake.packagerMutex.RLock()
 	defer fake.packagerMutex.RUnlock()
 	argsForCall := fake.packagerArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakePackagerFactory) PackagerReturns(result1 commandparser.Packager, result2 error) {

--- a/commandparser/package_stemcell.go
+++ b/commandparser/package_stemcell.go
@@ -23,7 +23,7 @@ type OSAndVersionGetter interface {
 
 //counterfeiter:generate . PackagerFactory
 type PackagerFactory interface {
-	Packager(sourceConfig config.SourceConfig, outputConfig config.OutputConfig, logLevel int, color bool) (Packager, error)
+	Packager(sourceConfig config.SourceConfig, outputConfig config.OutputConfig, logger colorlogger.Logger) (Packager, error)
 }
 
 //counterfeiter:generate . Packager
@@ -129,7 +129,8 @@ func (p *PackageCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		return subcommands.ExitFailure
 	}
 
-	packager, err := p.packagerFactory.Packager(p.sourceConfig, p.outputConfig, logLevel, p.GlobalFlags.Color)
+	logger := colorlogger.New(logLevel, p.GlobalFlags.Color, os.Stderr)
+	packager, err := p.packagerFactory.Packager(p.sourceConfig, p.outputConfig, logger)
 	if err != nil {
 		p.packagerMessenger.CannotCreatePackager(err)
 		return subcommands.ExitFailure

--- a/commandparser/package_stemcell_test.go
+++ b/commandparser/package_stemcell_test.go
@@ -62,7 +62,7 @@ var _ = Describe("package_stemcell", func() {
 				Expect(exitStatus).To(Equal(subcommands.ExitSuccess))
 
 				Expect(packagerFactory.PackagerCallCount()).To(Equal(1))
-				actualSourceConfig, _, _, _ := packagerFactory.PackagerArgsForCall(0)
+				actualSourceConfig, _, _ := packagerFactory.PackagerArgsForCall(0)
 				Expect(actualSourceConfig.Vmdk).To(Equal("some_vmdk_file"))
 			})
 
@@ -82,7 +82,7 @@ var _ = Describe("package_stemcell", func() {
 				Expect(exitStatus).To(Equal(subcommands.ExitSuccess))
 
 				Expect(packagerFactory.PackagerCallCount()).To(Equal(1))
-				actualSourceConfig, _, _, _ := packagerFactory.PackagerArgsForCall(0)
+				actualSourceConfig, _, _ := packagerFactory.PackagerArgsForCall(0)
 				Expect(actualSourceConfig.URL).To(Equal("https://vcenter.test"))
 				Expect(actualSourceConfig.Username).To(Equal("test-user"))
 				Expect(actualSourceConfig.Password).To(Equal("verysecure"))
@@ -100,7 +100,7 @@ var _ = Describe("package_stemcell", func() {
 				Expect(exitStatus).To(Equal(subcommands.ExitSuccess))
 
 				Expect(packagerFactory.PackagerCallCount()).To(Equal(1))
-				_, actualOutputConfig, _, _ := packagerFactory.PackagerArgsForCall(0)
+				_, actualOutputConfig, _ := packagerFactory.PackagerArgsForCall(0)
 				Expect(actualOutputConfig.OutputDir).To(Equal("some_output_dir"))
 			})
 
@@ -114,7 +114,7 @@ var _ = Describe("package_stemcell", func() {
 				Expect(exitStatus).To(Equal(subcommands.ExitSuccess))
 
 				Expect(packagerFactory.PackagerCallCount()).To(Equal(1))
-				_, actualOutputConfig, _, _ := packagerFactory.PackagerArgsForCall(0)
+				_, actualOutputConfig, _ := packagerFactory.PackagerArgsForCall(0)
 				Expect(actualOutputConfig.OutputDir).To(Equal("some_output_dir"))
 				Expect(actualOutputConfig.StemcellVersion).To(Equal("2019.2"))
 				Expect(actualOutputConfig.Os).To(Equal("2019"))
@@ -132,7 +132,7 @@ var _ = Describe("package_stemcell", func() {
 				Expect(exitStatus).To(Equal(subcommands.ExitSuccess))
 
 				Expect(packagerFactory.PackagerCallCount()).To(Equal(1))
-				_, actualOutputConfig, _, _ := packagerFactory.PackagerArgsForCall(0)
+				_, actualOutputConfig, _ := packagerFactory.PackagerArgsForCall(0)
 				Expect(actualOutputConfig.StemcellVersion).To(Equal("1803.27.36"))
 
 				Expect(oSAndVersionGetter.GetVersionWithPatchNumberCallCount()).To(Equal(1))

--- a/package_stemcell/factory/packager_factory.go
+++ b/package_stemcell/factory/packager_factory.go
@@ -29,10 +29,10 @@ func (f *PackagerFactory) Packager(sourceConfig config.SourceConfig, outputConfi
 		return vCenterPackager, nil
 	case config.VMDK:
 		options := package_parameters.VmdkPackageParameters{}
-		logger := colorlogger.ConstructLogger(logLevel, color, os.Stderr)
+		logger := colorlogger.New(logLevel, color, os.Stderr)
 		vmdkPackager := &packagers.VmdkPackager{
 			Stop:         make(chan struct{}),
-			Debugf:       logger.Debugf,
+			Debugf:       logger.Printf,
 			BuildOptions: options,
 		}
 

--- a/package_stemcell/factory/packager_factory.go
+++ b/package_stemcell/factory/packager_factory.go
@@ -2,7 +2,6 @@ package factory
 
 import (
 	"errors"
-	"os"
 	"strings"
 
 	"github.com/cloudfoundry/stembuild/colorlogger"
@@ -16,7 +15,7 @@ import (
 
 type PackagerFactory struct{}
 
-func (f *PackagerFactory) Packager(sourceConfig config.SourceConfig, outputConfig config.OutputConfig, logLevel int, color bool) (commandparser.Packager, error) {
+func (f *PackagerFactory) Packager(sourceConfig config.SourceConfig, outputConfig config.OutputConfig, logger colorlogger.Logger) (commandparser.Packager, error) {
 	source, err := sourceConfig.GetSource()
 	if err != nil {
 		return nil, err
@@ -29,7 +28,7 @@ func (f *PackagerFactory) Packager(sourceConfig config.SourceConfig, outputConfi
 		return vCenterPackager, nil
 	case config.VMDK:
 		options := package_parameters.VmdkPackageParameters{}
-		logger := colorlogger.New(logLevel, color, os.Stderr)
+
 		vmdkPackager := &packagers.VmdkPackager{
 			Stop:         make(chan struct{}),
 			Debugf:       logger.Printf,

--- a/package_stemcell/factory/packager_factory.go
+++ b/package_stemcell/factory/packager_factory.go
@@ -20,6 +20,7 @@ func (f *PackagerFactory) Packager(sourceConfig config.SourceConfig, outputConfi
 	if err != nil {
 		return nil, err
 	}
+
 	switch source {
 	case config.VCENTER:
 		runner := &iaas_cli.GovcRunner{}
@@ -27,12 +28,13 @@ func (f *PackagerFactory) Packager(sourceConfig config.SourceConfig, outputConfi
 		vCenterPackager := &packagers.VCenterPackager{SourceConfig: sourceConfig, OutputConfig: outputConfig, Client: client}
 		return vCenterPackager, nil
 	case config.VMDK:
-		options := package_parameters.VmdkPackageParameters{}
+		options :=
+			package_parameters.VmdkPackageParameters{}
 
 		vmdkPackager := &packagers.VmdkPackager{
 			Stop:         make(chan struct{}),
-			Debugf:       logger.Printf,
 			BuildOptions: options,
+			Logger:       logger,
 		}
 
 		vmdkPackager.BuildOptions.VMDKFile = sourceConfig.Vmdk

--- a/package_stemcell/factory/packager_factory.go
+++ b/package_stemcell/factory/packager_factory.go
@@ -23,10 +23,21 @@ func (f *PackagerFactory) Packager(sourceConfig config.SourceConfig, outputConfi
 
 	switch source {
 	case config.VCENTER:
-		runner := &iaas_cli.GovcRunner{}
-		client := iaas_clients.NewVcenterClient(sourceConfig.Username, sourceConfig.Password, sourceConfig.URL, sourceConfig.CaCertFile, runner)
-		vCenterPackager := &packagers.VCenterPackager{SourceConfig: sourceConfig, OutputConfig: outputConfig, Client: client}
-		return vCenterPackager, nil
+		client :=
+			iaas_clients.NewVcenterClient(
+				sourceConfig.Username,
+				sourceConfig.Password,
+				sourceConfig.URL,
+				sourceConfig.CaCertFile,
+				&iaas_cli.GovcRunner{},
+			)
+
+		return &packagers.VCenterPackager{
+			SourceConfig: sourceConfig,
+			OutputConfig: outputConfig,
+			Client:       client,
+			Logger:       logger,
+		}, nil
 	case config.VMDK:
 		options :=
 			package_parameters.VmdkPackageParameters{}

--- a/package_stemcell/factory/packager_factory_test.go
+++ b/package_stemcell/factory/packager_factory_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/cloudfoundry/stembuild/colorlogger"
 	"github.com/cloudfoundry/stembuild/package_stemcell/config"
 	"github.com/cloudfoundry/stembuild/package_stemcell/factory"
 	"github.com/cloudfoundry/stembuild/package_stemcell/packagers"
@@ -18,9 +19,11 @@ var _ = Describe("Factory", func() {
 	}
 
 	var packagerFactory *factory.PackagerFactory
+	var logger colorlogger.Logger
 
 	BeforeEach(func() {
 		packagerFactory = &factory.PackagerFactory{}
+		logger = colorlogger.New(0, false, GinkgoWriter)
 	})
 
 	Describe("GetPackager", func() {
@@ -30,7 +33,7 @@ var _ = Describe("Factory", func() {
 					Vmdk: "path/to/a/vmdk",
 				}
 
-				actualPackager, err := packagerFactory.Packager(sourceConfig, outputConfig, 0, false)
+				actualPackager, err := packagerFactory.Packager(sourceConfig, outputConfig, logger)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(actualPackager).To(BeAssignableToTypeOf(&packagers.VmdkPackager{}))
@@ -47,7 +50,7 @@ var _ = Describe("Factory", func() {
 					VmInventoryPath: "some-vm-inventory-path",
 				}
 
-				actualPackager, err := packagerFactory.Packager(sourceConfig, outputConfig, 0, false)
+				actualPackager, err := packagerFactory.Packager(sourceConfig, outputConfig, logger)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(actualPackager).To(BeAssignableToTypeOf(&packagers.VCenterPackager{}))
@@ -62,7 +65,7 @@ var _ = Describe("Factory", func() {
 					VmInventoryPath: "some-vm",
 				}
 
-				packager, err := packagerFactory.Packager(sourceConfig, outputConfig, 0, false)
+				packager, err := packagerFactory.Packager(sourceConfig, outputConfig, logger)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("configuration provided for VMDK & vCenter sources"))
 				Expect(packager).To(BeNil())
@@ -77,7 +80,7 @@ var _ = Describe("Factory", func() {
 					URL:             "some-url",
 				}
 
-				packager, err := packagerFactory.Packager(sourceConfig, outputConfig, 0, false)
+				packager, err := packagerFactory.Packager(sourceConfig, outputConfig, logger)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("missing vCenter configurations"))
 				Expect(packager).To(BeNil())
@@ -88,7 +91,7 @@ var _ = Describe("Factory", func() {
 			It("returns an error", func() {
 				sourceConfig := config.SourceConfig{}
 
-				packager, err := packagerFactory.Packager(sourceConfig, outputConfig, 0, false)
+				packager, err := packagerFactory.Packager(sourceConfig, outputConfig, logger)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("no configuration was provided"))
 				Expect(packager).To(BeNil())

--- a/package_stemcell/packagers/vcenter_packager.go
+++ b/package_stemcell/packagers/vcenter_packager.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/cloudfoundry/stembuild/colorlogger"
 	"github.com/cloudfoundry/stembuild/filesystem"
 	"github.com/cloudfoundry/stembuild/package_stemcell/config"
 )
@@ -27,6 +28,7 @@ type VCenterPackager struct {
 	SourceConfig config.SourceConfig
 	OutputConfig config.OutputConfig
 	Client       IaasClient
+	Logger       colorlogger.Logger
 }
 
 func (v VCenterPackager) Package() error {

--- a/package_stemcell/packagers/vmdk_packager_test.go
+++ b/package_stemcell/packagers/vmdk_packager_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/cloudfoundry/stembuild/colorlogger"
 	mockfilesystem "github.com/cloudfoundry/stembuild/filesystem/mock"
 	"github.com/cloudfoundry/stembuild/package_stemcell/package_parameters"
 	"github.com/cloudfoundry/stembuild/package_stemcell/packagers"
@@ -30,8 +31,8 @@ var _ = Describe("VmdkPackager", func() {
 
 		vmdkPackager = packagers.VmdkPackager{
 			Stop:         make(chan struct{}),
-			Debugf:       func(format string, a ...interface{}) {},
 			BuildOptions: stembuildConfig,
+			Logger:       colorlogger.New(0, false, GinkgoWriter),
 		}
 	})
 

--- a/remotemanager/winrm_remotemanager.go
+++ b/remotemanager/winrm_remotemanager.go
@@ -38,13 +38,14 @@ func NewWinRM(host string, username string, password string, clientFactory WinRM
 }
 
 func (w *WinRM) CanReachVM() error {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", w.host, WinRmPort), time.Duration(time.Second*60))
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", w.host, WinRmPort), time.Second*60)
 	if err != nil {
-		return fmt.Errorf("host %s is unreachable. Please ensure WinRM is enabled and the IP is correct: %s", w.host, err)
+		return fmt.Errorf("host %s is unreachable; lease ensure WinRM is enabled and the IP is correct: %w", w.host, err)
 	}
+
 	err = conn.Close()
 	if err != nil {
-		return fmt.Errorf("could not close connection to host %s: %s", w.host, err)
+		return fmt.Errorf("could not close connection to host %s: %w", w.host, err)
 	}
 
 	return nil
@@ -54,17 +55,17 @@ func (w *WinRM) CanLoginVM() error {
 	winrmClient, err := w.clientFactory.Build(WinRmTimeout)
 
 	if err != nil {
-		return fmt.Errorf("failed to create winrm client: %s", err)
+		return fmt.Errorf("failed to create winrm client: %w", err)
 	}
 
 	s, err := winrmClient.CreateShell()
 	if err != nil {
-		return fmt.Errorf("failed to create winrm shell: %s", err)
+		return fmt.Errorf("failed to create winrm shell: %w", err)
 	}
 
 	err = s.Close()
 	if err != nil {
-		return fmt.Errorf("failed to close winrm shell: %s", err)
+		return fmt.Errorf("failed to close winrm shell: %w", err)
 	}
 
 	return nil

--- a/remotemanager/winrm_remotemanager_test.go
+++ b/remotemanager/winrm_remotemanager_test.go
@@ -178,33 +178,34 @@ var _ = Describe("WinRM RemoteManager", func() {
 			remotemanager := remotemanager.NewWinRM("some-host", "some-user", "some-pass", winRMClientFactory)
 
 			err := remotemanager.CanLoginVM()
-
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("returns error if winrmclient cannot be created", func() {
 			winRMClientFactory := new(remotemanagerfakes.FakeWinRMClientFactoryI)
-			buildError := errors.New("unable to build a client")
-			winRMClientFactory.BuildReturns(nil, buildError)
+			buildErr := errors.New("unable to build a client")
+			winRMClientFactory.BuildReturns(nil, buildErr)
 
 			remotemanager := remotemanager.NewWinRM("some-host", "some-user", "some-pass", winRMClientFactory)
-			err := remotemanager.CanLoginVM()
 
+			err := remotemanager.CanLoginVM()
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(fmt.Errorf("failed to create winrm client: %s", buildError)))
+			Expect(err).To(MatchError(fmt.Errorf("failed to create winrm client: %w", buildErr)))
 		})
+
 		It("returns error if shell cannot be created", func() {
 			winRMClientFactory := new(remotemanagerfakes.FakeWinRMClientFactoryI)
 			winRMClient := new(remotemanagerfakes.FakeWinRMClient)
 			winRMClientFactory.BuildReturns(winRMClient, nil)
 
-			winRMClient.CreateShellReturns(nil, errors.New("some shell creation error"))
+			shellErr := errors.New("some shell creation error")
+			winRMClient.CreateShellReturns(nil, shellErr)
+
 			remotemanager := remotemanager.NewWinRM("some-host", "some-user", "some-pass", winRMClientFactory)
 
 			err := remotemanager.CanLoginVM()
-
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(fmt.Errorf("failed to create winrm shell: some shell creation error")))
+			Expect(err).To(MatchError(fmt.Errorf("failed to create winrm shell: %w", shellErr)))
 		})
 	})
 })


### PR DESCRIPTION
- colorlogger package looks _more_ like `log.Logger`
- `VCenterPackager` and `VmdkPackager` have a `Logger` member
- `VmdkPackager` uses `.Logger.Printf()` instead of bespoke `.Debugf()` member
